### PR TITLE
Add drop_all_tables utility and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,25 @@ ETL for trajectories
 
 
 ## Functions
-- `mat_points_view.py`: Creates a Materialized View for points
-- `create_cs_traj_stop_tables.py`: Creates CS tables for trajectory with stops
+- [`main.py`](/src/main.py): Main script to run all steps
+- [`drop_all_tables.py`](/src/tables/drop_all_tables.py): Drops all tables in the schema
+- [`mat_points_view.py`](/src/tables/mat_points_view.py): Creates a Materialized View for points
+- [`create_cs_traj_stop_tables.py`](/src/tables/create_cs_traj_stop_tables.py): Creates CS tables for trajectory with stops
+
+### [`main.py`](/src/main.py)
+Main script to run all steps in order: drop tables, create materialized view, create trajectory and stop tables.
+
+#### Run
+- Win: `python ./src/main.py`
+- Mac: `python3 src/main.py`
+
+### [`drop_all_tables.py`](/src/tables/drop_all_tables.py)
+Drops all tables in the PostgreSQL database (dw/prototype1/trajectory_cs, dw/prototype1/stop_cs, dw/prototype1/trajectory_ls, dw/prototype1/stop_poly, dw/prototype1/points).
 
 ### [`mat_points_view.py`](/src/tables/mat_points_view.py)
 Creates a materialized view named `points` in the PostgreSQL database (dw/ls_experiment/points). This view aggregates AIS points from a single MMSI taken from the `dw.fact.ais_point_fact` table. The resulting view contains six columns: `mmsi`, `geom` containing x, y, timestamp, `sog`, `cog`, `delta_sog`, `delta_depth_draught`.
 
 This prepares points that can then be used for trajectory generation with stops.
-#### Run
-- Win: `python ./src/tables/mat_points_view.py`
-- Mac: `python3 src/tables/mat_points_view.py`
 
-### `create_cs_traj_stop_tables.py`
+### [`create_cs_traj_stop_tables.py`](/src/tables/create_cs_traj_stop_tables.py)
 Creates one table for trajectory and one table for stops in the PostgreSQL database (dw/ls_experiment/trajectory_cs).
-
-#### Run
-- Win: `python ./src/tables/create_cs_traj_stop_tables.py`
-- Mac: `python3 src/tables/create_cs_traj_stop_tables.py`

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
 from connect import connect_to_db
+from tables.drop_all_tables import drop_all_tables
 from tables.create_ls_traj_stop_tables import create_ls_traj_stop_tables
 from tables.create_cs_traj_stop_tables import create_cs_traj_stop_tables
 from tables.mat_points_view import mat_points_view
@@ -10,7 +11,10 @@ def main():
     load_dotenv()
     
     connection = connect_to_db()
-    
+
+    # Drop existing tables and views
+    #drop_all_tables(connection)
+
     # Create LineString/Polygon tables Trajectory and Stop
     create_ls_traj_stop_tables(connection)
 

--- a/src/tables/drop_all_tables.py
+++ b/src/tables/drop_all_tables.py
@@ -1,0 +1,13 @@
+from psycopg import Connection
+
+def drop_all_tables(conn: Connection):
+    cur = conn.cursor()
+
+    # Drop tables if they exist
+    cur.execute("DROP TABLE IF EXISTS prototype1.trajectory_cs;")
+    cur.execute("DROP TABLE IF EXISTS prototype1.stop_cs;")
+    cur.execute("DROP TABLE IF EXISTS prototype1.trajectory_ls;")
+    cur.execute("DROP TABLE IF EXISTS prototype1.stop_poly;")
+    cur.execute("DROP MATERIALIZED VIEW IF EXISTS prototype1.points;")
+
+    print("Dropped all tables and materialized view if they existed.")

--- a/src/tables/mat_points_view.py
+++ b/src/tables/mat_points_view.py
@@ -5,11 +5,6 @@ def mat_points_view(conn: Connection):
 
     # Example MMSI for testing
     mmsi = "210051000, 636015105"
-
-    # language=SQL
-    cur.execute("""
-            DROP MATERIALIZED VIEW IF EXISTS ls_experiment.POINTS;
-        """)
     
     cur.execute(f"""
             -- POINTM's with MMSI
@@ -55,7 +50,7 @@ def mat_points_view(conn: Connection):
             ON ls_experiment.POINTS USING GIST (geom) INCLUDE (mmsi);
         """)
 
-    print("Created materialized view POINTS")
+    print("Created materialized view POINTS if not exists.")
 
     conn.commit()
     cur.close()


### PR DESCRIPTION
Introduced drop_all_tables.py to remove tables and views from the database. Updated README with clearer instructions and script descriptions. Refactored main.py to import drop_all_tables (currently commented out). Improved mat_points_view.py by removing redundant drop statement and clarifying output message.